### PR TITLE
Added Camera Image Capture to Scott's Raven 

### DIFF
--- a/modalities/dom/components/elements/camera-input.js
+++ b/modalities/dom/components/elements/camera-input.js
@@ -1,0 +1,94 @@
+/*
+@license
+Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+
+import Xen from '../xen/xen.js';
+
+let template = Xen.html`
+<video id="player"  autoplay ></video>
+<canvas id="canvas" style="display: none;" width="640" height="480"></canvas>
+<br/>
+<span>
+    <button id="recordbutton" on-click="record">Start Recording</button>
+    <button id="capturebutton" on-click="capture">Take Picture</button>
+</span>
+`;
+template = Xen.Template.createTemplate(template);
+
+//const log = Xen.logFactory('MicInput', 'blue');
+
+const constraints = {
+  video: true,
+};
+
+class CameraInput extends Xen.Base {
+
+  get template() {
+    return template;
+  }
+
+  _didMount() {
+    this.player = this.host.getElementById('player');
+    this.canvas = this.host.getElementById('canvas');
+    this.ctx = this.canvas.getContext('2d');
+    this.isRecording = false;
+  }
+
+  record() {
+
+    navigator.mediaDevices.getUserMedia(constraints)
+      .then((stream) => {
+        if (!this.isRecording) {
+          this.player.srcObject = stream;
+          this.player.play();
+        } else {
+          this._stop();
+        }
+        this.isRecording = !this.isRecording;
+      });
+  }
+
+  _stop() {
+    navigator.mediaDevices.getUserMedia(constraints)
+      .then((stream) => {
+        this.player.pause();
+        stream.getVideoTracks().forEach((track) => track.stop());
+      });
+  }
+
+  _update(props, state) {
+  }
+
+  _render(props, state) {
+    return state;
+  }
+
+  start() {
+
+  }
+
+  stop() {
+
+  }
+
+  capture() {
+    this._stop();
+    // Draw whatever is in the video element on to the canvas.
+    this.ctx.drawImage(this.player, 0, 0);
+    const imageData = this.ctx.getImageData(0, 0, 640, 480);
+    this.value = {
+      pixels: imageData.data, width: imageData.width, height: imageData.height,
+      url: this.canvas.toDataURL('image/png')
+    };
+    this._fire('capture', this.value);
+  }
+
+}
+
+customElements.define('camera-input', CameraInput);

--- a/modalities/dom/components/elements/camera-input.js
+++ b/modalities/dom/components/elements/camera-input.js
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 import Xen from '../xen/xen.js';
 
 let template = Xen.html`
-<video id="player"  autoplay ></video>
+<video id="player" width="640" height="480" autoplay ></video>
 <canvas id="canvas" style="display: none;" width="640" height="480"></canvas>
 <br/>
 <span>
@@ -25,6 +25,7 @@ template = Xen.Template.createTemplate(template);
 
 const constraints = {
   video: true,
+  audio: false,
 };
 
 class CameraInput extends Xen.Base {
@@ -41,25 +42,23 @@ class CameraInput extends Xen.Base {
   }
 
   record() {
-
     navigator.mediaDevices.getUserMedia(constraints)
       .then((stream) => {
         if (!this.isRecording) {
           this.player.srcObject = stream;
           this.player.play();
+          this.isRecording = true;
         } else {
           this._stop();
         }
-        this.isRecording = !this.isRecording;
       });
   }
 
   _stop() {
-    navigator.mediaDevices.getUserMedia(constraints)
-      .then((stream) => {
-        this.player.pause();
-        stream.getVideoTracks().forEach((track) => track.stop());
-      });
+    this.player.srcObject.getVideoTracks().forEach((track) => track.stop());
+    this.player.srcObject = null;
+    this.player.pause();
+    this.isRecording = false;
   }
 
   _update(props, state) {
@@ -78,7 +77,6 @@ class CameraInput extends Xen.Base {
   }
 
   capture() {
-    this._stop();
     // Draw whatever is in the video element on to the canvas.
     this.ctx.drawImage(this.player, 0, 0);
     const imageData = this.ctx.getImageData(0, 0, 640, 480);
@@ -86,6 +84,7 @@ class CameraInput extends Xen.Base {
       pixels: imageData.data, width: imageData.width, height: imageData.height,
       url: this.canvas.toDataURL('image/png')
     };
+    this._stop();
     this._fire('capture', this.value);
   }
 

--- a/particles/Processing/HighGranularity.recipes
+++ b/particles/Processing/HighGranularity.recipes
@@ -1,4 +1,5 @@
 import 'particles/ImageCapture.particle'
+import 'particles/VideoCapture.particle'
 import 'particles/MlModelCapture.particle'
 import 'particles/ImageProcessSelector.particle'
 import 'particles/ImageProcessing.particle'
@@ -10,6 +11,11 @@ recipe ImageCapture
   create #volatile as image
   ImageCapture
   description `load an image from a url`
+
+recipe VideoCapture
+  create #volatile as image
+  VideoCapture
+  description `capture an image from a webcam`
 
 store UdnieModel of MlModelUrl 'udnie-model' in 'assets/udnie.json'
 

--- a/particles/Processing/particles/VideoCapture.particle
+++ b/particles/Processing/particles/VideoCapture.particle
@@ -1,0 +1,6 @@
+import '../schemas/Image.schema'
+
+particle VideoCapture in './source/VideoCapture.js'
+  out ImageUrl image
+  consume root
+    provide imageView

--- a/particles/Processing/particles/source/VideoCapture.js
+++ b/particles/Processing/particles/source/VideoCapture.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+'use strict';
+
+/* global defineParticle */
+
+defineParticle(({DomParticle, html}) => {
+
+  const tmpl = html`
+    <div style="padding: 16px;">
+      <h2>Arcs Image Processing Demo</h2>
+      <h3>Capture an image with your webcamera</h3>
+      <camera-input on-capture="onCapture"></camera-input>
+      <br><br>
+      <img src="{{url}}">
+      <br><br>
+      <div slotid="imageView"></div>
+    </div>
+  `;
+
+  return class extends DomParticle {
+    get template() {
+      return tmpl; }
+    render(props, state) {
+      // if (!state.inputUrl) {
+      //   state.inputUrl = 'https://$particles/Processing/assets/kitten.jpg';
+      // }
+      return state;
+    }
+    onCapture(data) {
+      const {pixels, width, height, url} = data.data.value;
+      this.setState({url: url, blob: {
+          blob: new Uint8Array(pixels.buffer),
+          width: width,
+          height: height
+        }});
+      this.updateVariable('image', {url});
+    }
+  };
+
+});

--- a/shells/configuration/whitelisted.js
+++ b/shells/configuration/whitelisted.js
@@ -9,6 +9,7 @@ import '../../modalities/dom/components/elements/geo-location.js';
 import '../../modalities/dom/components/elements/model-input.js';
 import '../../modalities/dom/components/elements/model-img.js';
 import '../../modalities/dom/components/elements/dom-repeater.js';
+import '../../modalities/dom/components/elements/camera-input.js';
 import '../../modalities/dom/components/elements/processing/image-processor.js';
 import '../../modalities/dom/components/elements/processing/image-styler.js';
 import '../../modalities/dom/components/elements/processing/image-helper.js';


### PR DESCRIPTION
## Summary
- Added Ray's video capture framework to Scott's highly-granular recipe
- Improved the video capture component to stop capture after image is taken.  

## How to Verify
- build + run: `./tools/sigh webpack && npm start`
- select the particle with `webcam` in it
- Expected: should capture an image, show the image, then turn off the webcam
- Thereafter, apply a classifier and/or stylers (use `*` in the search to get suggestions). 